### PR TITLE
feat: 댓글 조회 기능 구현

### DIFF
--- a/src/main/java/com/kdt/localinfo/comment/controller/CommentController.java
+++ b/src/main/java/com/kdt/localinfo/comment/controller/CommentController.java
@@ -15,6 +15,7 @@ import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
 import java.net.URI;
+import java.util.List;
 
 import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.linkTo;
 import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.methodOn;
@@ -53,5 +54,16 @@ public class CommentController {
                 linkTo(methodOn(CommentController.class).save(postId, commentSaveRequest, errors)).withSelfRel());
 
         return ResponseEntity.created(createdUri).body(entityModel);
+    }
+
+    @GetMapping(path = "/posts/{post-id}/comments", produces = MediaTypes.HAL_JSON_VALUE, consumes = MediaTypes.HAL_JSON_VALUE)
+    public ResponseEntity<EntityModel<List<CommentResponse>>> findAllByPostId(@PathVariable("post-id") Long postId) throws NotFoundException {
+        log.info("findAllByPostId execute");
+        List<CommentResponse> commentResponses = commentService.findAllByPostId(postId);
+
+        EntityModel<List<CommentResponse>> entityModel = EntityModel.of(commentResponses,
+                linkTo(methodOn(CommentController.class).findAllByPostId(postId)).withSelfRel());
+
+        return ResponseEntity.ok(entityModel);
     }
 }

--- a/src/main/java/com/kdt/localinfo/comment/entity/Comment.java
+++ b/src/main/java/com/kdt/localinfo/comment/entity/Comment.java
@@ -9,6 +9,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
+import java.time.LocalDateTime;
 import java.util.Objects;
 
 @Builder
@@ -39,6 +40,10 @@ public class Comment extends BaseEntity {
         }
         this.post = post;
         post.getComments().add(this);
+    }
+
+    public void setDeleted(){
+        this.deletedAt = LocalDateTime.now();
     }
 
     public void setUser(User user) {

--- a/src/main/java/com/kdt/localinfo/comment/repository/CommentRepository.java
+++ b/src/main/java/com/kdt/localinfo/comment/repository/CommentRepository.java
@@ -1,7 +1,11 @@
 package com.kdt.localinfo.comment.repository;
 
 import com.kdt.localinfo.comment.entity.Comment;
+import com.kdt.localinfo.post.entity.Post;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface CommentRepository extends JpaRepository<Comment, Long> {
+    List<Comment> findAllByPost(Post post);
 }

--- a/src/main/java/com/kdt/localinfo/comment/service/CommentService.java
+++ b/src/main/java/com/kdt/localinfo/comment/service/CommentService.java
@@ -14,6 +14,9 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.ArrayList;
+import java.util.List;
+
 @Slf4j
 @Service
 public class CommentService {
@@ -44,5 +47,22 @@ public class CommentService {
         Comment commentEntity = commentRepository.save(comment);
 
         return commentConverter.converterToCommentResponse(commentEntity);
+    }
+
+    @Transactional
+    public List<CommentResponse> findAllByPostId(Long postId) throws NotFoundException {
+        Post post = postRepository.findById(postId)
+                .orElseThrow(() -> new NotFoundException("게시물에 대한 정보를 찾을 수 없습니다."));
+
+        List<Comment> comments = commentRepository.findAllByPost(post);
+
+        List<CommentResponse> commentResponses = new ArrayList<>();
+
+        comments.forEach(comment -> {
+            CommentResponse commentResponse = commentConverter.converterToCommentResponse(comment);
+            commentResponses.add(commentResponse);
+        });
+
+        return commentResponses;
     }
 }

--- a/src/main/java/com/kdt/localinfo/comment/service/CommentService.java
+++ b/src/main/java/com/kdt/localinfo/comment/service/CommentService.java
@@ -14,8 +14,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Slf4j
 @Service
@@ -56,13 +56,9 @@ public class CommentService {
 
         List<Comment> comments = commentRepository.findAllByPost(post);
 
-        List<CommentResponse> commentResponses = new ArrayList<>();
-
-        comments.forEach(comment -> {
-            CommentResponse commentResponse = commentConverter.converterToCommentResponse(comment);
-            commentResponses.add(commentResponse);
-        });
-
-        return commentResponses;
+        return comments.stream()
+                .filter(comment -> comment.getDeletedAt() == null)
+                .map(commentConverter::converterToCommentResponse)
+                .collect(Collectors.toList());
     }
 }

--- a/src/main/java/com/kdt/localinfo/post/entity/Post.java
+++ b/src/main/java/com/kdt/localinfo/post/entity/Post.java
@@ -39,7 +39,7 @@ public class Post extends BaseEntity {
     @JoinColumn(name = "category_id", nullable = false)
     private Category category;
 
-    @OneToMany(mappedBy = "post", cascade = CascadeType.ALL)
+    @OneToMany(mappedBy = "post", cascade = CascadeType.REMOVE)
     private List<Comment> comments = new ArrayList<>();
 
     @JsonBackReference

--- a/src/main/java/com/kdt/localinfo/user/entity/User.java
+++ b/src/main/java/com/kdt/localinfo/user/entity/User.java
@@ -48,7 +48,7 @@ public class User extends BaseEntity {
     @OneToMany(mappedBy = "user", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     private final List<Post> posts = new ArrayList<>();
 
-    @OneToMany(mappedBy = "user", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+    @OneToMany(mappedBy = "user", fetch = FetchType.LAZY, cascade = CascadeType.REMOVE)
     private final List<Comment> comments = new ArrayList<>();
 
 }

--- a/src/test/java/com/kdt/localinfo/LocalInfoApplicationTests.java
+++ b/src/test/java/com/kdt/localinfo/LocalInfoApplicationTests.java
@@ -2,7 +2,9 @@ package com.kdt.localinfo;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
+@ActiveProfiles("test")
 @SpringBootTest
 class LocalInfoApplicationTests {
 

--- a/src/test/java/com/kdt/localinfo/comment/controller/CommentControllerTest.java
+++ b/src/test/java/com/kdt/localinfo/comment/controller/CommentControllerTest.java
@@ -111,25 +111,25 @@ class CommentControllerTest {
         Post savePost = postRepository.save(post1);
 
         Comment comment = Comment.builder()
-                .post(savePost)
                 .contents("댓글")
-                .user(saveUser)
                 .build();
+        comment.setPost(savePost);
+        comment.setUser(saveUser);
+
         Comment comment2 = Comment.builder()
-                .post(savePost)
                 .contents("댓글")
-                .user(saveUser)
                 .build();
-        Comment savedComment = commentRepository.save(comment);
+        comment2.setPost(savePost);
+        comment2.setUser(saveUser);
+
+        commentRepository.save(comment);
         commentRepository.save(comment2);
 
-        mockMvc.perform(get("/posts/{post-id}/comments", savedComment.getPost().getId())
+        mockMvc.perform(get("/posts/{post-id}/comments", savePost.getId())
                         .accept(MediaTypes.HAL_JSON_VALUE)
                         .contentType(MediaTypes.HAL_JSON_VALUE))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("_links.self").exists())
                 .andDo(print());
-
-
     }
 }

--- a/src/test/java/com/kdt/localinfo/comment/controller/CommentControllerTest.java
+++ b/src/test/java/com/kdt/localinfo/comment/controller/CommentControllerTest.java
@@ -4,6 +4,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.kdt.localinfo.category.Category;
 import com.kdt.localinfo.category.CategoryRepository;
 import com.kdt.localinfo.comment.dto.CommentSaveRequest;
+import com.kdt.localinfo.comment.entity.Comment;
+import com.kdt.localinfo.comment.repository.CommentRepository;
 import com.kdt.localinfo.post.entity.Post;
 import com.kdt.localinfo.post.repository.PostRepository;
 import com.kdt.localinfo.user.entity.Region;
@@ -18,6 +20,7 @@ import org.springframework.hateoas.MediaTypes;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -42,6 +45,9 @@ class CommentControllerTest {
 
     @Autowired
     private PostRepository postRepository;
+
+    @Autowired
+    private CommentRepository commentRepository;
 
     @Test
     @DisplayName("댓글 생성")
@@ -79,4 +85,51 @@ class CommentControllerTest {
                 .andDo(print());
     }
 
+    @Test
+    @DisplayName("게시글 아이디로 댓글 조회")
+    void findAllByPostIdTest() throws Exception {
+        Region region = Region.builder()
+                .city("고양시")
+                .district("덕양구")
+                .neighborhood("행신동")
+                .build();
+        User user = User.builder()
+                .email("email1")
+                .region(region)
+                .nickname("nickname")
+                .password("password")
+                .name("name")
+                .build();
+        User saveUser = userRepository.save(user);
+        Category category = new Category(1L, "동네생활");
+        Category saveCategory = categoryRepository.save(category);
+        Post post1 = Post.builder()
+                .contents("this is sample post")
+                .region(region)
+                .category(saveCategory).build();
+        post1.setUser(saveUser);
+        Post savePost = postRepository.save(post1);
+
+        Comment comment = Comment.builder()
+                .post(savePost)
+                .contents("댓글")
+                .user(saveUser)
+                .build();
+        Comment comment2 = Comment.builder()
+                .post(savePost)
+                .contents("댓글")
+                .user(saveUser)
+                .build();
+        Comment savedComment = commentRepository.save(comment);
+        commentRepository.save(comment2);
+
+        mockMvc.perform(get("/posts/{post-id}/comments", savedComment.getPost().getId())
+                        .accept(MediaTypes.HAL_JSON_VALUE)
+                        .contentType(MediaTypes.HAL_JSON_VALUE))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("_links.self").exists())
+                .andDo(print());
+
+
+    }
 }

--- a/src/test/java/com/kdt/localinfo/comment/controller/CommentControllerTest.java
+++ b/src/test/java/com/kdt/localinfo/comment/controller/CommentControllerTest.java
@@ -119,10 +119,12 @@ class CommentControllerTest {
         comment.setUser(saveUser);
 
         Comment comment2 = Comment.builder()
-                .contents("댓글")
+                .contents("댓글2")
                 .build();
         comment2.setPost(savePost);
         comment2.setUser(saveUser);
+
+        comment.setDeleted();
 
         commentRepository.save(comment);
         commentRepository.save(comment2);
@@ -131,6 +133,7 @@ class CommentControllerTest {
                         .accept(MediaTypes.HAL_JSON_VALUE)
                         .contentType(MediaTypes.HAL_JSON_VALUE))
                 .andExpect(status().isOk())
+                .andExpect(jsonPath("$._embedded.commentResponseList..contents").value("댓글2"))
                 .andExpect(jsonPath("_links.self").exists())
                 .andDo(print());
     }

--- a/src/test/java/com/kdt/localinfo/comment/controller/CommentControllerTest.java
+++ b/src/test/java/com/kdt/localinfo/comment/controller/CommentControllerTest.java
@@ -101,8 +101,10 @@ class CommentControllerTest {
                 .name("name")
                 .build();
         User saveUser = userRepository.save(user);
+
         Category category = new Category(1L, "동네생활");
         Category saveCategory = categoryRepository.save(category);
+
         Post post1 = Post.builder()
                 .contents("this is sample post")
                 .region(region)

--- a/src/test/java/com/kdt/localinfo/comment/service/CommentServiceTest.java
+++ b/src/test/java/com/kdt/localinfo/comment/service/CommentServiceTest.java
@@ -1,15 +1,14 @@
 package com.kdt.localinfo.comment.service;
 
-import com.kdt.localinfo.category.Category;
 import com.kdt.localinfo.comment.converter.CommentConverter;
+import com.kdt.localinfo.comment.dto.CommentDepth;
 import com.kdt.localinfo.comment.dto.CommentResponse;
 import com.kdt.localinfo.comment.dto.CommentSaveRequest;
 import com.kdt.localinfo.comment.entity.Comment;
 import com.kdt.localinfo.comment.repository.CommentRepository;
+import com.kdt.localinfo.common.TestEntityFactory;
 import com.kdt.localinfo.post.entity.Post;
 import com.kdt.localinfo.post.repository.PostRepository;
-import com.kdt.localinfo.user.entity.Region;
-import com.kdt.localinfo.user.entity.Role;
 import com.kdt.localinfo.user.entity.User;
 import com.kdt.localinfo.user.repository.UserRepository;
 import javassist.NotFoundException;
@@ -22,13 +21,15 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
-import java.util.Set;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.*;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.times;
 
 @ExtendWith(MockitoExtension.class)
 class CommentServiceTest {
@@ -49,58 +50,81 @@ class CommentServiceTest {
     @DisplayName("댓글 생성")
     void saveTest() throws NotFoundException {
         // GIVEN
-        Region region = Region.builder().city("고양시").district("덕양구").neighborhood("행신동").build();
+        Comment comment = TestEntityFactory.commentBuilder().build();
+        User user = comment.getUser();
+        Post post = comment.getPost();
 
-        User user = User.builder()
-                .id(1L)
-                .name("choi")
-                .password("1234")
-                .email("test@gmail.com")
-                .nickname("0kwon")
-                .region(region)
-                .roles(Set.of(Role.GENERAL))
-                .build();
-
-        Post post = Post.builder()
-                .id(1L)
-                .category(new Category(1L, "동네 맛집"))
-                .region(region)
-                .contents("테스트 게시글")
-                .build();
-        post.setUser(user);
-
-        CommentSaveRequest commentSaveRequest = new CommentSaveRequest(1L, "안녕하세요 댓글입니다.");
+        CommentSaveRequest commentSaveRequest = new CommentSaveRequest(user.getId(), "안녕하세요 댓글입니다.");
 
         Comment expectComment = commentConverter.converterToComment(commentSaveRequest, user, post);
 
-        CommentResponse expectCommentResponse = new CommentResponse(1L,
+        CommentResponse expectCommentResponse = new CommentResponse(comment.getId(),
                 "안녕하세요 댓글입니다.",
                 user.getNickname(),
                 LocalDateTime.now(),
                 user.getRegion().getNeighborhood(),
                 null,
-                0L);
+                checkedDepth(comment.getParentId()));
 
-        given(userRepository.findById(1L)).willReturn(Optional.of(user));
-        given(postRepository.findById(1L)).willReturn(Optional.of(post));
+        given(userRepository.findById(user.getId())).willReturn(Optional.of(user));
+        given(postRepository.findById(post.getId())).willReturn(Optional.of(post));
         given(commentConverter.converterToComment(commentSaveRequest, user, post)).willReturn(expectComment);
         given(commentConverter.converterToCommentResponse(expectComment)).willReturn(expectCommentResponse);
 
         // WHEN
-        CommentResponse commentResponse = commentService.save(commentSaveRequest, 1L);
+        CommentResponse commentResponse = commentService.save(commentSaveRequest, post.getId());
 
         // THEN
-        verify(userRepository, times(1)).findById(user.getId());
-        verify(postRepository, times(1)).findById(post.getId());
-        Comment comment = verify(commentConverter, atLeastOnce()).converterToComment(commentSaveRequest, user, post);
-        verify(commentRepository, times(1)).save(comment);
-        verify(commentConverter, times(1)).converterToCommentResponse(comment);
-
         assertThat(commentResponse.getId(), is(expectCommentResponse.getId()));
         assertThat(commentResponse.getContents(), is(expectCommentResponse.getContents()));
         assertThat(commentResponse.getParentId(), is(expectCommentResponse.getParentId()));
         assertThat(commentResponse.getDepth(), is(expectCommentResponse.getDepth()));
         assertThat(commentResponse.getRegion(), is(expectCommentResponse.getRegion()));
         assertThat(commentResponse.getNickName(), is(expectCommentResponse.getNickName()));
+    }
+
+    @Test
+    void findAllByPostIdTest() throws NotFoundException {
+
+        // GIVEN
+        Comment comment = TestEntityFactory.commentBuilder().build();
+
+        CommentResponse commentResponse = new CommentResponse(comment.getId(),
+                comment.getContents(),
+                comment.getUser().getNickname(),
+                comment.getUpdatedAt(),
+                comment.getUser().getRegion().getNeighborhood(),
+                comment.getParentId(),
+                checkedDepth(comment.getParentId()));
+
+        List<Comment> returnComments = new ArrayList<>();
+        returnComments.add(comment);
+        returnComments.add(comment);
+
+        Post post = comment.getPost();
+        Long postId = post.getId();
+
+        given(commentRepository.findAllByPost(post)).willReturn(returnComments);
+        given(postRepository.findById(postId)).willReturn(Optional.of(post));
+        given(commentConverter.converterToCommentResponse(comment)).willReturn(commentResponse);
+
+        // WHEN
+        List<CommentResponse> commentResponses = commentService.findAllByPostId(postId);
+
+        // THEN
+        then(postRepository).should().findById(postId);
+        then(commentRepository).should().findAllByPost(post);
+        then(commentConverter).should(times(2)).converterToCommentResponse(comment);
+
+        assertThat(commentResponses.size(), is(2));
+        commentResponses.forEach(commentResponse1 -> {
+            assertThat(commentResponse1.getNickName(), is("nickName"));
+            assertThat(commentResponse1.getDepth(), is(0L));
+            assertThat(commentResponse1.getContents(), is("댓글"));
+        });
+    }
+
+    private Long checkedDepth(Long parentId) {
+        return parentId == null ? CommentDepth.ZERO.getDepth() : CommentDepth.ONE.getDepth();
     }
 }

--- a/src/test/java/com/kdt/localinfo/comment/service/CommentServiceTest.java
+++ b/src/test/java/com/kdt/localinfo/comment/service/CommentServiceTest.java
@@ -84,6 +84,7 @@ class CommentServiceTest {
     }
 
     @Test
+    @DisplayName("게시글 아이디로 댓글 조회 Service")
     void findAllByPostIdTest() throws NotFoundException {
 
         // GIVEN

--- a/src/test/java/com/kdt/localinfo/common/TestEntityFactory.java
+++ b/src/test/java/com/kdt/localinfo/common/TestEntityFactory.java
@@ -10,35 +10,6 @@ import com.kdt.localinfo.user.entity.User;
 import java.util.Set;
 
 public class TestEntityFactory {
-    public static User.UserBuilder userBuilder() {
-        return User.builder()
-                .id(1L)
-                .roles(Set.of(Role.GENERAL))
-                .region(new Region("고양시", "덕양구", "행신동"))
-                .name("test")
-                .password("1234")
-                .nickname("nickName")
-                .email("test@gmail.com");
-    }
-
-    public static Post.PostBuilder postBuilder() {
-        User user = User.builder()
-                .id(1L)
-                .roles(Set.of(Role.GENERAL))
-                .region(new Region("고양시", "덕양구", "행신동"))
-                .name("test")
-                .password("1234")
-                .nickname("nickName")
-                .email("test@gmail.com")
-                .build();
-
-        return Post.builder()
-                .id(1L)
-                .contents("게시글")
-                .category(new Category(1L, "동네 맛집"))
-                .region(user.getRegion());
-    }
-
     public static Comment.CommentBuilder commentBuilder() {
         User user = User.builder()
                 .id(1L)

--- a/src/test/java/com/kdt/localinfo/common/TestEntityFactory.java
+++ b/src/test/java/com/kdt/localinfo/common/TestEntityFactory.java
@@ -1,0 +1,67 @@
+package com.kdt.localinfo.common;
+
+import com.kdt.localinfo.category.Category;
+import com.kdt.localinfo.comment.entity.Comment;
+import com.kdt.localinfo.post.entity.Post;
+import com.kdt.localinfo.user.entity.Region;
+import com.kdt.localinfo.user.entity.Role;
+import com.kdt.localinfo.user.entity.User;
+
+import java.util.Set;
+
+public class TestEntityFactory {
+    public static User.UserBuilder userBuilder() {
+        return User.builder()
+                .id(1L)
+                .roles(Set.of(Role.GENERAL))
+                .region(new Region("고양시", "덕양구", "행신동"))
+                .name("test")
+                .password("1234")
+                .nickname("nickName")
+                .email("test@gmail.com");
+    }
+
+    public static Post.PostBuilder postBuilder() {
+        User user = User.builder()
+                .id(1L)
+                .roles(Set.of(Role.GENERAL))
+                .region(new Region("고양시", "덕양구", "행신동"))
+                .name("test")
+                .password("1234")
+                .nickname("nickName")
+                .email("test@gmail.com")
+                .build();
+
+        return Post.builder()
+                .id(1L)
+                .contents("게시글")
+                .category(new Category(1L, "동네 맛집"))
+                .region(user.getRegion());
+    }
+
+    public static Comment.CommentBuilder commentBuilder() {
+        User user = User.builder()
+                .id(1L)
+                .roles(Set.of(Role.GENERAL))
+                .region(new Region("고양시", "덕양구", "행신동"))
+                .name("test")
+                .password("1234")
+                .nickname("nickName")
+                .email("test@gmail.com")
+                .build();
+
+        Post post = Post.builder()
+                .id(1L)
+                .contents("게시글")
+                .category(new Category(1L, "동네 맛집"))
+                .region(user.getRegion())
+                .build();
+        post.setUser(user);
+
+        return Comment.builder()
+                .id(1L)
+                .contents("댓글")
+                .user(user)
+                .post(post);
+    }
+}

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -13,3 +13,10 @@ spring:
       ddl-auto: create-drop
     database-platform: org.hibernate.dialect.MySQL8Dialect
     show-sql: true
+
+server:
+  servlet:
+    encoding:
+      force: true
+      enabled: true
+      charset: UTF-8


### PR DESCRIPTION
## 📌 이슈 설명 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->
- #30
## ✅ PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
- 게시글 Id로 댓글을 조회하는 기능을 구현 했습니다.
- [7c65ab](https://github.com/prgrms-be-devcourse/BEDV1_LocalInfo/commit/7c65ab4eb8f3ca057af26f35ec87bc0e82be5ff4)에서 테스트용 엔티티 펙토리를 만들었습니다. 
  - 테스트 하실 때 해당 메서드를 사용해서 엔티티를 사용하면 좀 더 코드를 깔끔하게 작성할 수 있을 것 같습니다.
- 테스트 할 때 한글이 깨지는 것을 방지하기 위해 인코딩 설정을 했습니다.
