### PR TITLE
v1.1 배포 중 버그 수정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -96,3 +96,7 @@ task copyConfigSettings(type: Copy) {
 build {
     dependsOn copyConfigSettings
 }
+
+jar {
+    enabled = false
+}


### PR DESCRIPTION
* 사용하지 않는 submodule 내 파일 제거
* plain jar 생성되지 않도록 수정 설정 추가
```Groovy
jar {
    enabled=false
}
```